### PR TITLE
fix "FieldError: Unknown field(s) (username) specified for User"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
   - 3.4
   - 3.3
@@ -10,11 +12,15 @@ env:
   - DJANGO="Django>=1.7,<1.8"
   - DJANGO="Django>=1.6,<1.7"
   - DJANGO="Django>=1.5,<1.6"
-  
+  - DJANGO="Django>=1.8,<1.9" DJANGO_AUTH_USER_MODEL=auth.CustomUser
+  - DJANGO="Django>=1.7,<1.8" DJANGO_AUTH_USER_MODEL=auth.CustomUser
+  - DJANGO="Django>=1.6,<1.7" DJANGO_AUTH_USER_MODEL=auth.CustomUser
+  - DJANGO="Django>=1.5,<1.6" DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
 install:
   - pip install -U coverage coveralls django-etc $DJANGO
 
-  
+
 script: coverage run -a --source=sitegate sitegate/runtests.py
 
 matrix:

--- a/sitegate/runtests.py
+++ b/sitegate/runtests.py
@@ -17,7 +17,8 @@ def main():
                 'django.contrib.auth',
                 'django.contrib.contenttypes',
                 'django.contrib.sessions',
-                'etc', APP_NAME
+                'etc',
+                APP_NAME,
             ),
             DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3'}},
             MIDDLEWARE_CLASSES=(
@@ -26,7 +27,11 @@ def main():
                 'django.contrib.auth.middleware.AuthenticationMiddleware',
                 'django.contrib.messages.middleware.MessageMiddleware',
             ),
-            ROOT_URLCONF = 'sitegate.tests',
+            ROOT_URLCONF='sitegate.tests',
+            MIGRATION_MODULES={
+                'auth': 'django.contrib.auth.tests.migrations',
+            },
+            AUTH_USER_MODEL=os.environ.get('DJANGO_AUTH_USER_MODEL', 'auth.User')
         )
 
     try:  # Django 1.7 +

--- a/sitegate/signup_flows/classic.py
+++ b/sitegate/signup_flows/classic.py
@@ -12,6 +12,9 @@ from ..models import BlacklistedDomain, EmailConfirmation
 from ..settings import SIGNUP_VERIFY_EMAIL_BODY, SIGNUP_VERIFY_EMAIL_TITLE, SIGNUP_VERIFY_EMAIL_NOTICE, SIGNUP_VERIFY_EMAIL_VIEW_NAME
 
 
+USERNAME_FIELD = getattr(USER, 'USERNAME_FIELD', 'username')
+
+
 class ClassicSignupForm(UserCreationForm):
     """Classic form tuned to support custom user model."""
 
@@ -22,7 +25,7 @@ class ClassicSignupForm(UserCreationForm):
 
     class Meta:
         model = USER
-        fields = ('username',)
+        fields = (USERNAME_FIELD,)
 
     def clean_username(self):
         username = self.cleaned_data['username']
@@ -70,7 +73,10 @@ class ClassicWithEmailSignupForm(ClassicSignupForm):
 
     class Meta:
         model = USER
-        fields = ('username', 'email', 'password1', 'password2')
+        if USERNAME_FIELD != 'email':
+            fields = (USERNAME_FIELD, 'email', 'password1', 'password2')
+        else:
+            fields = (USERNAME_FIELD, 'password1', 'password2')
 
     def __init__(self, *args, **kwargs):
         super(ClassicWithEmailSignupForm, self).__init__(*args, **kwargs)

--- a/sitegate/signup_flows/classic.py
+++ b/sitegate/signup_flows/classic.py
@@ -7,17 +7,12 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib import messages
 
 from .base import SignupFlow
-from ..utils import get_user_model
+from ..utils import USER
 from ..models import BlacklistedDomain, EmailConfirmation
 from ..settings import SIGNUP_VERIFY_EMAIL_BODY, SIGNUP_VERIFY_EMAIL_TITLE, SIGNUP_VERIFY_EMAIL_NOTICE, SIGNUP_VERIFY_EMAIL_VIEW_NAME
 
 
-# Using get_username_field method instead if simple variable assignment
-# because tests may overrider user_model for some test-cases
-# Note: Using get_user_model() instead of utils.USER for the same reason
-def get_username_field():
-    return getattr(get_user_model(), 'USERNAME_FIELD', 'username')
-
+USERNAME_FIELD = getattr(USER, 'USERNAME_FIELD', 'username')
 
 
 class ClassicSignupForm(UserCreationForm):
@@ -30,16 +25,15 @@ class ClassicSignupForm(UserCreationForm):
     })
 
     class Meta:
-        model = get_user_model()
-        fields = (get_username_field(),)
+        model = USER
+        fields = (USERNAME_FIELD,)
 
     def __init__(self, *args, **kwargs):
         super(ClassicSignupForm, self).__init__(*args, **kwargs)
-        if get_username_field() != 'username' and 'username' in self.fields:
+        if USERNAME_FIELD != 'username' and 'username' in self.fields:
             del self.fields['username']
 
     def clean_username(self):
-        USER = get_user_model()
         username = self.cleaned_data['username']
         try:
             USER._default_manager.get(username=username)
@@ -84,8 +78,7 @@ class ClassicWithEmailSignupForm(ClassicSignupForm):
     email = forms.EmailField(label=_('Email'))
 
     class Meta:
-        model = get_user_model()
-        USERNAME_FIELD = get_username_field()
+        model = USER
         if USERNAME_FIELD != 'email':
             fields = (USERNAME_FIELD, 'email', 'password1', 'password2')
         else:

--- a/sitegate/signup_flows/modern.py
+++ b/sitegate/signup_flows/modern.py
@@ -13,7 +13,8 @@ class ModernSignupForm(SimpleClassicWithEmailSignupForm):
 
     def __init__(self, *args, **kwargs):
         super(ModernSignupForm, self).__init__(*args, **kwargs)
-        del self.fields['username']
+        if 'username' in self.fields:
+            del self.fields['username']
 
     def clean_email(self):
         email = super(ModernSignupForm, self).clean_email()

--- a/sitegate/tests.py
+++ b/sitegate/tests.py
@@ -34,7 +34,7 @@ from sitegate.signin_flows.modern import *
 from sitegate.models import *
 from sitegate.toolbox import *
 from sitegate.views import verify_email, messages
-from sitegate.utils import USER
+from sitegate.utils import USER, get_username_field
 
 
 class MockUser(object):

--- a/sitegate/utils.py
+++ b/sitegate/utils.py
@@ -12,6 +12,8 @@ except ImportError:
     USER = User
     get_user_model = lambda: USER
 
+get_username_field = lambda: getattr(USER, 'USERNAME_FIELD', 'username')
+
 
 class DecoratorBuilder(object):
     """Decorators builder. Facilitates decorators creation.

--- a/sitegate/utils.py
+++ b/sitegate/utils.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     from django.contrib.auth.models import User
     USER = User
+    get_user_model = lambda: USER
 
 
 class DecoratorBuilder(object):

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,7 @@
 [tox]
 envlist =
-    py27-django15,
-    py27-django16,
-    py27-django17,
-    py27-django18,
-
-    py3-django15,
-    py3-django16,
-    py3-django17,
-    py3-django18
+    {py27,py3}-django{15,16,17,18},
+    {py27,py3}-django{15,16,17,18}-customuser
 
 
 [django15]
@@ -59,3 +52,52 @@ deps = {[django17]deps}
 [testenv:py3-django18]
 basepython = python3
 deps = {[django18]deps}
+
+
+[testenv:py27-django15-customuser]
+basepython = python2.7
+deps = {[django15]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py27-django16-customuser]
+basepython = python2.7
+deps = {[django16]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py27-django17-customuser]
+basepython = python2.7
+deps = {[django17]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py27-django18-customuser]
+basepython = python2.7
+deps = {[django18]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py3-django15-customuser]
+basepython = python3
+deps = {[django15]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py3-django16-customuser]
+basepython = python3
+deps = {[django16]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py3-django17-customuser]
+basepython = python3
+deps = {[django17]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser
+
+[testenv:py3-django18-customuser]
+basepython = python3
+deps = {[django18]deps}
+setenv =
+    DJANGO_AUTH_USER_MODEL=auth.CustomUser

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
-    {py27,py3}-django{15,16,17,18},
-    {py27,py3}-django{15,16,17,18}-customuser
+    {py27,py3}-django{15,16,17,18}{,-customuser}
 
 
 [django15]


### PR DESCRIPTION
When usermodel have 'USERNAME_FIELD' different from 'username' then importing any signup flow will result in exception: 
```python
    # ... try to import Signup flows and/or form:
    from sitegate.signup_flows.modern import ModernSignup, ModernSignupForm
  File "/home/imposeren/.virtualenvs/tabletop/local/lib/python2.7/site-packages/sitegate/signup_flows/modern.py", line 6, in <module>
    from .classic import SimpleClassicWithEmailSignup, SimpleClassicWithEmailSignupForm
  File "/home/imposeren/.virtualenvs/tabletop/local/lib/python2.7/site-packages/sitegate/signup_flows/classic.py", line 15, in <module>
    class ClassicSignupForm(UserCreationForm):
  File "/home/imposeren/.virtualenvs/tabletop/local/lib/python2.7/site-packages/django/forms/models.py", line 295, in __new__
    raise FieldError(message)

django.core.exceptions.FieldError: Unknown field(s) (username) specified for User
```

this pull request will fix this