### PR TITLE
confirming email changes

### DIFF
--- a/docs/source/signup_tweaks.rst
+++ b/docs/source/signup_tweaks.rst
@@ -108,6 +108,9 @@ Current confirmation view provides same messages for registration confirmation a
 	        messages.error(request, _("To confirm email change you should login as user whose email is being changed"), 'danger error')
 	    elif not valid_code.user.is_active:
 	        messages.error(request, _("User is not active anymore: can't change email"), 'danger error')
+	    else:
+	        messages.error(request, _("Another unknown error')
+
 
 	    if redirect_to is None:
 	        redirect_to = '/'

--- a/docs/source/signup_tweaks.rst
+++ b/docs/source/signup_tweaks.rst
@@ -46,7 +46,7 @@ to take some additional steps:
 
 * You're done. Upon registration user will be notified he needs to confirm his email address.
 
-    An email with account activation link will be sent by **django-sitemessage**.
+    An email with account activation link will be sent by **django-sitemessage** or by **django.core.mail.send_mail** when django-sitemessage is not available
 
 
 .. note::
@@ -55,3 +55,57 @@ to take some additional steps:
 
     See :ref:`Preferences <email-prefs>` chapter.
 
+
+
+Sending confirmation email for changed emails
+---------------------------------------------
+
+View for email confirmation can also be used to confirm email changes. Django-sitegate does not provide
+means to actually initiate email change so it's up to you to actually validate new emails, to generate required ``EmailConfirmation`` instance, tpgenerate activation url, to send email with url.
+
+Example of generating url for included confirmation view:
+
+.. code-block:: python
+
+    from sitegate.models import EmailConfirmation
+    from sitegate.settings import SIGNUP_VERIFY_EMAIL_VIEW_NAME
+    from django.contrib.auth import get_user_model
+
+    some_user = get_user_model().objects.all().first()
+    code = EmailConfirmation.add(user=some_user, new_email='other_email@domain.com')
+
+    email_confirmation_url = request.build_absolute_uri(reverse(SIGNUP_VERIFY_EMAIL_VIEW_NAME, args=(code.code,)))
+
+    # now you can generate some email with this url and sendit to new email of user.
+
+
+.. warning::
+
+   This approach does not send anything to old email! It only ensures that new email is valid.
+   So if someone will gain access to authorised user session on site then he or she will be able to change
+   email without access to old mailbox.
+
+
+If **settings.SIGNUP_VERIFY_EMAIL_ALLOW_DUPLICATES** is ``False`` (the default) then confirmation view will fail
+if user tries to change email to email of exising user. But it's better to perform this check in your email change form.
+Current confirmation view provides same messages for registration confirmation and email change confirmation. You can create your own confirmation view, example:
+
+.. code-block:: python
+
+	def custom_verify_email(request, code, redirect_to=None):
+	    success = False
+
+	    valid_code = EmailConfirmation.is_valid(code)
+	    if valid_code and valid_code.user.is_active:  # also verify that user is already activated
+	        valid_code.activate()
+	        success = True
+
+	    if success:
+	        messages.success(request, _("Change of email confirmed"), 'success')
+	    else:
+	        messages.error(request, SIGNUP_VERIFY_EMAIL_ERROR_TEXT, 'danger error')
+
+	    if redirect_to is None:
+	        redirect_to = '/'
+
+	    return redirect(redirect_to)

--- a/docs/source/signup_tweaks.rst
+++ b/docs/source/signup_tweaks.rst
@@ -96,14 +96,18 @@ Current confirmation view provides same messages for registration confirmation a
 	    success = False
 
 	    valid_code = EmailConfirmation.is_valid(code)
-	    if valid_code and valid_code.user.is_active:  # also verify that user is already activated
+
+	    # more secure confirmation: require user to be active and logged int
+	    if valid_code and valid_code.user.is_active and valid_code.user == request.user
 	        valid_code.activate()
 	        success = True
 
 	    if success:
 	        messages.success(request, _("Change of email confirmed"), 'success')
-	    else:
-	        messages.error(request, SIGNUP_VERIFY_EMAIL_ERROR_TEXT, 'danger error')
+	    elif request.user != valid_code.user:
+	        messages.error(request, _("To confirm email change you should login as user whose email is being changed"), 'danger error')
+	    elif not valid_code.user.is_active:
+	        messages.error(request, _("User is not active anymore: can't change email"), 'danger error')
 
 	    if redirect_to is None:
 	        redirect_to = '/'

--- a/sitegate/__init__.py
+++ b/sitegate/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (0, 10, 2)
+VERSION = (0, 10, 3)
 
 
 default_app_config = 'sitegate.config.SitegateConfig'

--- a/sitegate/migrations/0002_emailconfirmation_new_email.py
+++ b/sitegate/migrations/0002_emailconfirmation_new_email.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sitegate', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='emailconfirmation',
+            name='new_email',
+            field=models.EmailField(default=None, max_length=254, null=True, verbose_name='email address', blank=True),
+        ),
+    ]

--- a/sitegate/models.py
+++ b/sitegate/models.py
@@ -136,13 +136,14 @@ class EmailConfirmation(InheritedModel, ModelWithCode):
 
     @classmethod
     def is_valid(cls, code):
+        from .utils import USER
         code = super(EmailConfirmation, cls).is_valid(code)
         if not code or code.new_email is None:
             return code
 
         if not SIGNUP_VERIFY_EMAIL_ALLOW_DUPLICATES:
             code = code
-            if USER_MODEL.objects.filter(email=code.new_email).exclude(pk=code.user_id).exists():
+            if USER.objects.filter(email=code.new_email).exclude(pk=code.user_id).exists():
                 return False
             else:
                 return code

--- a/sitegate/settings.py
+++ b/sitegate/settings.py
@@ -26,6 +26,7 @@ SIGNUP_VERIFY_EMAIL_ERROR_TEXT = getattr(
     _('Unable to verify an e-mail. User account was not activated.'))
 
 SIGNUP_VERIFY_EMAIL_VIEW_NAME = getattr(settings, 'SITEGATE_SIGNUP_VERIFY_EMAIL_VIEW_NAME', 'verify_email')
+SIGNUP_VERIFY_EMAIL_ALLOW_DUPLICATES = getattr(settings, 'SIGNUP_VERIFY_EMAIL_ALLOW_DUPLICATES', False)
 
 try:
     from siteprefs.toolbox import patch_locals, register_prefs, pref, pref_group

--- a/sitegate/south_migrations/0005_auto__add_field_emailconfirmation_new_email.py
+++ b/sitegate/south_migrations/0005_auto__add_field_emailconfirmation_new_email.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'EmailConfirmation.new_email'
+        db.add_column(u'sitegate_emailconfirmation', 'new_email',
+                      self.gf('django.db.models.fields.EmailField')(default=None, max_length=75, null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'EmailConfirmation.new_email'
+        db.delete_column(u'sitegate_emailconfirmation', 'new_email')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'sitegate.blacklisteddomain': {
+            'Meta': {'object_name': 'BlacklistedDomain'},
+            'domain': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '253'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'sitegate.emailconfirmation': {
+            'Meta': {'object_name': 'EmailConfirmation'},
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'expired': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_email': ('django.db.models.fields.EmailField', [], {'default': 'None', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'time_accepted': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'time_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'sitegate.invitationcode': {
+            'Meta': {'object_name': 'InvitationCode'},
+            'acceptor': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'acceptors'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'code': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'creators'", 'to': u"orm['auth.User']"}),
+            'expired': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'time_accepted': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'time_created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['sitegate']


### PR DESCRIPTION
I think that it's good to have ability to validate email changes with same model and view that are used to confirm emails on registration. This pull request adds easy way to do so with docs. For default config nothing will change: developers should provide their own methods to generate required DB rows and emails
