### PR TITLE
Fix import in "Combining sign in flows" example

### DIFF
--- a/docs/source/signin_custom.rst
+++ b/docs/source/signin_custom.rst
@@ -83,7 +83,7 @@ You can use more than one sign in flow with the same view, by stacking ``@signin
     from django.shortcuts import render
 
     from sitegate.signin_flows.classic import ClassicSignin
-    from sitegate.decorators import signup_view
+    from sitegate.decorators import signin_view
 
     # We'll use some our mythical MySignin flow, so let's import it.
     from .my_signin_flows import MySignin


### PR DESCRIPTION
Typo imports signup_view instead of signin_view from sitegate.decorators